### PR TITLE
Makes project links in Portfolio section more visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -381,8 +381,9 @@ ol.type li a:hover {
 	width: 80%;
 }
 
-#portfolio strong a {
-	text-decoration: underline;
+#portfolio button {
+	font-size: 18px;
+	margin-right: 10px;
 }
 /* Achivements Section */
 #achievements {

--- a/index.html
+++ b/index.html
@@ -189,14 +189,12 @@
                   including those owned by other users.
                 </p>
                 <p><strong>Technologies used: </strong>Ruby on Rails, React, Redux</p>
-                <nav>
-                  <button>
-                    <a href="https://github.com/jmkaneshiro/stayontrack" target="_blank" title="StayOnTrack Git">Github</a>
-                  </button>
-                  <button>
-                    <a href="https://stay-on-track-app.herokuapp.com/" target="_blank" title="StayOnTrack Live">Live Site</a>
-                  </button>
-                </nav>
+                <button>
+                  <a href="https://github.com/jmkaneshiro/stayontrack" target="_blank" title="StayOnTrack Git">Github</a>
+                </button>
+                <button>
+                  <a href="https://stay-on-track-app.herokuapp.com/" target="_blank" title="StayOnTrack Live">Live Site</a>
+                </button>
               </figcaption>
             </figure>
           </div>

--- a/index.html
+++ b/index.html
@@ -188,14 +188,15 @@
                   Users can create projects with stories of three kinds: features, bugs, and chores. A user can be a member of multiple projects,
                   including those owned by other users.
                 </p>
-                <strong>
-                  <p>
-                    <a href="https://github.com/jmkaneshiro/stayontrack" target="_blank" title="StayOnTrack Git">Github</a> | 
+                <p><strong>Technologies used: </strong>Ruby on Rails, React, Redux</p>
+                <nav>
+                  <button>
+                    <a href="https://github.com/jmkaneshiro/stayontrack" target="_blank" title="StayOnTrack Git">Github</a>
+                  </button>
+                  <button>
                     <a href="https://stay-on-track-app.herokuapp.com/" target="_blank" title="StayOnTrack Live">Live Site</a>
-                  </p>
-                </strong>
-                <h3>Technologies Used</h3>
-                <p>Ruby on Rails, React, Redux</p>
+                  </button>
+                </nav>
               </figcaption>
             </figure>
           </div>
@@ -214,14 +215,13 @@
                   Built during the 2020 Covid-19 epidemic with three classmates at App Academy, this app allows users to report and geolocate stores 
                   in their neighborhoods that have toilet paper in stock. If a report is accurate, logged in neighbors can verify it with a thumbs up.
                 </p>
-                <strong>
-                  <p>
-                    <a href="https://github.com/Solomon-T/instock" target="_blank" title="InStock Git">Github</a> |
-                    <a href="http://nstockapp.herokuapp.com/" target="_blank" title="InStock Live">Live Site</a>
-                  </p>
-                </strong>
-                <h3>Technologies Used</h3>
-                <p>JavaScript, HTML5, CSS3, Leaflet.js, GeoJSON</p>
+                <p><strong>Technologies Used: </strong>MongoDB, Express, React, Node.js, Google Maps API</p>
+                <button>
+                  <a href="https://github.com/Solomon-T/instock" target="_blank" title="InStock Git">Github</a>
+                </button>
+                <button>
+                  <a href="http://nstockapp.herokuapp.com/" target="_blank" title="InStock Live">Live Site</a>
+                </button>
               </figcaption>
             </figure>
           </div>
@@ -243,14 +243,15 @@
                   in a whimsical and informative way. Users can view records squirrel sightings on a Google Map and 
                   learn about the experiences of the 323 squirrel sighters involved in the project.
                 </p>
-                <strong>
-                  <p>
-                    <a href="https://github.com/jmkaneshiro/squirrels-of-central-park" target="_blank" title="Squirrels of Central Park Git">Github</a> |
-                    <a href="https://jmkaneshiro.github.io/squirrels-of-central-park/" target="_blank" title="Squirrels of Central Park Live">Live Site</a>
-                  </p>
-                </strong>
-                <h3>Technologies Used</h3>
-                <p>JavaScript, HTML5, CSS3, Leaflet.js, GeoJSON</p>
+                <p><strong>Technologies used: </strong>JavaScript, HTML5, CSS3, Leaflet.js, GeoJSON</p>
+                <button>
+                  <a href="https://github.com/jmkaneshiro/squirrels-of-central-park" target="_blank"
+                  title="Squirrels of Central Park Git">Github</a>
+                </button>
+                <button>
+                  <a href="https://jmkaneshiro.github.io/squirrels-of-central-park/" target="_blank"
+                  title="Squirrels of Central Park Live">Live Site</a>
+                </button>
               </figcaption>
             </figure>
           </div>


### PR DESCRIPTION
### Summary
Removes the h-tag for "Technologies used" on each portfolio item so that the the descriptions are more clearly connected to the project being described.

Changes anchor tags to buttons for links to Github and Live page for easier access.